### PR TITLE
Add export

### DIFF
--- a/assets/css/index.sass
+++ b/assets/css/index.sass
@@ -92,6 +92,3 @@ $bottom-bar-height: 25px
                margin-left: 20px
 
         font-size: 10px;
-
-    #export
-        display: none;

--- a/assets/css/index.sass
+++ b/assets/css/index.sass
@@ -92,3 +92,6 @@ $bottom-bar-height: 25px
                margin-left: 20px
 
         font-size: 10px;
+
+    #export
+        display: none;

--- a/assets/js/data.coffee
+++ b/assets/js/data.coffee
@@ -309,11 +309,14 @@ class Data
     @saveFile filename, mimetype, content
 
   saveFile: (filename, mimetype, content) ->
+    if not $?
+      return content # Tests are running
     $("#export").attr("download", filename)
     $("#export").attr("href", "data: #{mimetype};charset=utf-8,#{encodeURIComponent(content)}")
     $("#export")[0].click()
     $("#export").attr("download", null)
     $("#export").attr("href", null)
+    return content
 
 # exports
 module?.exports = Data

--- a/assets/js/data.coffee
+++ b/assets/js/data.coffee
@@ -306,11 +306,14 @@ class Data
         content = (line for line in exportLines jsonContent).join "\n"
     else
         throw "Invalid export format"
-    $("a#export").attr("download", filename)
-    $("a#export").attr("href", "data: #{mimetype};charset=utf-8,#{encodeURIComponent(content)}")
-    $("a#export")[0].click()
-    $("a#export").attr("download", null)
-    $("a#export").attr("href", null)
+    do @saveFile filename, mimetype, content
+
+  saveFile: (filename, mimetype, content) ->
+    $("#export").attr("download", filename)
+    $("#export").attr("href", "data: #{mimetype};charset=utf-8,#{encodeURIComponent(content)}")
+    $("#export")[0].click()
+    $("#export").attr("download", null)
+    $("#export").attr("href", null)
 
 # exports
 module?.exports = Data

--- a/assets/js/data.coffee
+++ b/assets/js/data.coffee
@@ -306,7 +306,7 @@ class Data
         content = (line for line in exportLines jsonContent).join "\n"
     else
         throw "Invalid export format"
-    do @saveFile filename, mimetype, content
+    @saveFile filename, mimetype, content
 
   saveFile: (filename, mimetype, content) ->
     $("#export").attr("download", filename)

--- a/assets/js/keyBindings.coffee
+++ b/assets/js/keyBindings.coffee
@@ -354,6 +354,10 @@ class KeyBindings
             fn: selectRow.bind(@, row)
           }
         return results
+    EXPORT:
+      display: 'Save a file'
+      fn: () ->
+        @view.data.export "vimflowy.txt"
     RECORD_MACRO:
       display: 'Begin/stop recording a macro'
     PLAY_MACRO:
@@ -424,6 +428,8 @@ class KeyBindings
     'alt+l': 'ZOOM_IN'
     'alt+j': 'NEXT_SIBLING'
     'alt+k': 'PREV_SIBLING'
+
+    'ctrl+s': 'EXPORT'
 
     'z': 'TOGGLE_FOLD'
     '[': 'ZOOM_OUT'

--- a/tests/testcase.coffee
+++ b/tests/testcase.coffee
@@ -45,7 +45,7 @@ class TestCase
       '\n!'
 
   expectExport: (fileExtension, expected) ->
-    export_ = @data.export "vimflowy.#{fileExtension}"
+    export_ = @data.exportContent fileExtension
     assert.equal export_, expected,
       "Expected \n#{export_}\n To match \n#{expected}\n!"
 

--- a/tests/testcase.coffee
+++ b/tests/testcase.coffee
@@ -44,4 +44,9 @@ class TestCase
       'To match \n' + JSON.stringify(expected, null, 2) +
       '\n!'
 
+  expectExport: (fileExtension, expected) ->
+    export_ = @data.export "vimflowy.#{fileExtension}"
+    assert.equal export_, expected,
+      "Expected \n#{export_}\n To match \n#{expected}\n!"
+
 module.exports = TestCase

--- a/tests/tests/export.coffee
+++ b/tests/tests/export.coffee
@@ -1,0 +1,23 @@
+TestCase = require '../testcase.coffee'
+
+# Test export formats
+t = new TestCase [
+  { line: 'first', children: [
+    'second'
+  ] },
+  'third'
+]
+t.expectExport 'txt', "- \n  - first\n    - second\n  - third"
+t.expectExport 'json', "{\n  \"line\": \"\",\n  \"children\": [\n    {\n      \"line\": \"first\",\n      \"children\": [\n        \"second\"\n      ]\n    },\n    \"third\"\n  ]\n}"
+
+
+# Make sure zoom does not affect export
+t = new TestCase [
+  { line: 'first', children: [
+    'second'
+  ] },
+  'third'
+]
+t.sendKey 'down'
+t.sendKey 'alt+l'
+t.expectExport 'txt', "- \n  - first\n    - second\n  - third"

--- a/tests/tests/export.coffee
+++ b/tests/tests/export.coffee
@@ -7,8 +7,8 @@ t = new TestCase [
   ] },
   'third'
 ]
-t.expectExport 'txt', "- \n  - first\n    - second\n  - third"
-t.expectExport 'json', "{\n  \"line\": \"\",\n  \"children\": [\n    {\n      \"line\": \"first\",\n      \"children\": [\n        \"second\"\n      ]\n    },\n    \"third\"\n  ]\n}"
+t.expectExport 'text/plain', "- \n  - first\n    - second\n  - third"
+t.expectExport 'application/json', "{\n  \"line\": \"\",\n  \"children\": [\n    {\n      \"line\": \"first\",\n      \"children\": [\n        \"second\"\n      ]\n    },\n    \"third\"\n  ]\n}"
 
 
 # Make sure zoom does not affect export
@@ -20,4 +20,4 @@ t = new TestCase [
 ]
 t.sendKey 'down'
 t.sendKey 'alt+l'
-t.expectExport 'txt', "- \n  - first\n    - second\n  - third"
+t.expectExport 'text/plain', "- \n  - first\n    - second\n  - third"

--- a/views/index.jade
+++ b/views/index.jade
@@ -12,3 +12,5 @@ block content
   #bottom-bar
     #mode.center
     #exInput
+
+  a#export

--- a/views/index.jade
+++ b/views/index.jade
@@ -13,4 +13,4 @@ block content
     #mode.center
     #exInput
 
-  a#export
+  a#export.hidden


### PR DESCRIPTION
Add export functionality via `ctrl+s`. Two exports formats are available:

1. Plaintext (compatible with workflowy)
2. JSON (indented nicely)

Currently, if you press `ctrl+s` it just saves a file called `vimflowy.txt` automatically. This is pretty much what I'd want, but I can also add any extras you want. For reference, Workflowy chooses to show you a textbox you can copy-paste from instead of using a file.

I haven't added an import option because I want to talk about how the UX should work first.