### PR TITLE
Aliasing

### DIFF
--- a/assets/js/actions.coffee
+++ b/assets/js/actions.coffee
@@ -151,7 +151,7 @@
         next = siblings[index]
       else
         next = if index == 0 then parent else siblings[index - 1]
-        if next == view.data.viewRoot
+        if next.id == view.data.viewRoot.id
           next = view.data.addChild parent
           @created = next
 

--- a/assets/js/actions.coffee
+++ b/assets/js/actions.coffee
@@ -96,15 +96,11 @@
       return "row #{@row}"
 
     apply: (view) ->
-      @parent = view.data.getParent @row
-      @index = view.data.indexOf @row
-
-      if @row == view.root then throw 'Cannot delete root'
-
-      view.data.detach @row
+      if @row.id == view.data.root.id then throw 'Cannot delete root'
+      @detached = view.data.detach @row
 
     rewind: (view) ->
-      view.data.attachChild @parent, @row, @index
+      view.data.attachChild @detached.parent, @row, @detached.index
 
   class AttachBlock extends Action
     constructor: (row, parent, index = -1, options = {}) ->

--- a/assets/js/cursor.coffee
+++ b/assets/js/cursor.coffee
@@ -5,13 +5,13 @@ if module?
 class Cursor
   constructor: (data, row = null, col = null, moveCol = null) ->
     @data = data
-    @row = if row == null then (@data.getChildren @data.viewRoot)[0] else row
-    @col = if col == null then 0 else col
+    @row = row ? (@data.getChildren @data.viewRoot)[0]
+    @col = col ? 0
     @properties = {}
     do @_getPropertiesFromContext
 
     # -1 means last col
-    @moveCol = if moveCol == null then col else moveCol
+    @moveCol = moveCol ? col
 
   clone: () ->
     return new Cursor @data, @row, @col, @moveCol

--- a/assets/js/cursor.coffee
+++ b/assets/js/cursor.coffee
@@ -271,9 +271,9 @@ class Cursor
 
   parent: (cursorOptions = {}) ->
     row = @data.getParent @row
-    if row == @data.root
+    if row.id == @data.root.id
       return
-    if row == @data.viewRoot
+    if row.id == @data.viewRoot.id
       @data.changeViewRoot @data.getParent row
     @setRow row, cursorOptions
 

--- a/assets/js/data.coffee
+++ b/assets/js/data.coffee
@@ -113,7 +113,7 @@ class Data
       @store.setMark row.id, mark
 
   getAllMarks: () ->
-    _.map @store.getAllMarks, @canonicalInstance, @
+    _.mapObject (do @store.getAllMarks), @canonicalInstance, @
 
   #############
   # structure #
@@ -148,8 +148,8 @@ class Data
     # This probably isn't as performant as it could be for how often it gets called, but I'd rather make it called less often before optimizing.
     if id == @root.id
       return @root
-    parent = (@store.getParents id)[0]
-    canonicalParent = @canonicalInstance parent.id
+    parentId = (@store.getParents id)[0]
+    canonicalParent = @canonicalInstance parentId
     children = @getChildren canonicalParent
     return _.find children, (sib) ->
       sib.id == id

--- a/assets/js/data.coffee
+++ b/assets/js/data.coffee
@@ -106,14 +106,14 @@ class Data
     @store.setAllMarks allMarks
     return true
 
-  setMark: (id, mark = '') ->
+  setMark: (row, mark = '') ->
     # update allMarks mapping
-    if @_updateAllMarks id, mark
+    if @_updateAllMarks row, mark
       # update row's mark
-      @store.setMark id, mark
+      @store.setMark row.id, mark
 
   getAllMarks: () ->
-    return do @store.getAllMarks
+    _.map @store.getAllMarks, @canonicalInstance, @
 
   #############
   # structure #
@@ -145,6 +145,7 @@ class Data
 
   canonicalInstance: (id) -> # Given an id (for example with search or mark), return a row with that id
     # TODO: try to optimize for one in the viewroot
+    # This probably isn't as performant as it could be for how often it gets called, but I'd rather make it called less often before optimizing.
     if id == @root.id
       return @root
     parent = (@store.getParents id)[0]
@@ -436,7 +437,7 @@ class Data
     if @collapsed row
       struct.collapsed = true
 
-    mark = @store.getMark row
+    mark = @store.getMark row.id
     if mark
       struct.mark = mark
 

--- a/assets/js/data.coffee
+++ b/assets/js/data.coffee
@@ -176,11 +176,11 @@ class Data
     children.splice ci, 1
     parents = @getParents row
     pi = _.findIndex parents, (par) ->
-        par.id == parent.id
+        par == parent.id
     parents.splice pi, 1
 
-    @store.setChildren parent, children
-    @store.setParents row, parents
+    @store.setChildren parent.id, children
+    @store.setParents row.id, parents
 
     mark = @getMark row
     if mark

--- a/assets/js/data.coffee
+++ b/assets/js/data.coffee
@@ -232,7 +232,8 @@ class Data
   # attaches a detached child to a parent
   # the child should not have a parent already
   attachChild: (row, child, index = -1) ->
-    @attachChildren row, [child], index
+    children = @attachChildren row, [child], index
+    return children[0]
 
   attachChildren: (row, new_children, index = -1) ->
     children = @getChildren row
@@ -248,6 +249,7 @@ class Data
       @attachMarks child
 
     @store.setChildren row.id, children
+    return new_children
 
   nextVisible: (row = @viewRoot) ->
     if @viewable row
@@ -347,6 +349,9 @@ class Data
     child = { id: do @store.getNew }
     @attachChild row, child, index
     return child
+
+  cloneRow: (row, parent, index = -1) ->
+    @attachChildren parent, row, index
 
   # this is never used, since data structure is basically persistent
   # deleteRow: (row) ->

--- a/assets/js/data.coffee
+++ b/assets/js/data.coffee
@@ -146,10 +146,13 @@ class Data
   canonicalInstance: (id) -> # Given an id (for example with search or mark), return a row with that id
     # TODO: try to optimize for one in the viewroot
     # This probably isn't as performant as it could be for how often it gets called, but I'd rather make it called less often before optimizing.
+    unless id? then return
     if id == @root.id
       return @root
     parentId = (@store.getParents id)[0]
     canonicalParent = @canonicalInstance parentId
+    if not canonicalParent
+      return
     children = @getChildren canonicalParent
     return _.find children, (sib) ->
       sib.id == id
@@ -320,15 +323,15 @@ class Data
     return child
 
   # this is never used, since data structure is basically persistent
-  # deleteRow: (id) ->
-  #   if id == @viewRoot.id
+  # deleteRow: (row) ->
+  #   if row.id == @viewRoot.id
   #     throw 'Cannot delete view root'
 
-  #   for child in (@getChildren id).slice()
+  #   for child in (@getChildren row).slice()
   #     @deleteRow child
 
-  #   @detach id
-  #   @store.delete id
+  #   @detach row
+  #   @store.delete row.id
 
   _insertSiblingHelper: (row, after) ->
     if row.id == @viewRoot.id

--- a/assets/js/data.coffee
+++ b/assets/js/data.coffee
@@ -6,11 +6,13 @@ if module?
   Logger = require('./logger.coffee')
 
 class Data
-  root: 0
+  root:
+    id: 0
+    crumbs: { parent: 0, crumbs: { parent: 0 } } # make it enough layers to guard against any bugs, but not circular because serialization
 
   constructor: (store) ->
     @store = store
-    @viewRoot = do @store.getLastViewRoot
+    @viewRoot = do @store.getLastViewRoot || @root
     return @
 
   changeViewRoot: (row) ->
@@ -29,7 +31,7 @@ class Data
   # }
   # in the case where all properties are false, it may be simply the character (to save space)
   getLine: (row) ->
-    return (@store.getLine row).map (obj) ->
+    return (@store.getLine row.id).map (obj) ->
       if typeof obj == 'string'
         obj = {
           char: obj
@@ -43,7 +45,7 @@ class Data
     return @getLine(row)[col]?.char
 
   setLine: (row, line) ->
-    return (@store.setLine row, (line.map (obj) ->
+    return (@store.setLine row.id, (line.map (obj) ->
       # if no properties are true, serialize just the character to save space
       if _.all constants.text_properties.map ((property) => (not obj[property]))
         return obj.char
@@ -86,21 +88,21 @@ class Data
   # marks #
   #########
 
-  getMark: (id) ->
-    return (@store.getMark id) || ''
+  getMark: (row) ->
+    return (@store.getMark row.id) || ''
 
-  _updateAllMarks: (id, mark = '') ->
+  _updateAllMarks: (row, mark = '') ->
     allMarks = do @store.getAllMarks
 
     if mark of allMarks
       return false
 
-    oldmark = @store.getMark id
+    oldmark = @store.getMark row.id
     if oldmark
       delete allMarks[oldmark]
 
     if mark
-      allMarks[mark] = id
+      allMarks[mark] = row.id
     @store.setAllMarks allMarks
     return true
 
@@ -118,161 +120,189 @@ class Data
   #############
 
   getParent: (row) ->
-    return @store.getParent row
+    return { id: row.crumbs.parent, crumbs: row.crumbs.crumbs }
+
+  getParents: (row) ->
+    return @store.getParents row.id
 
   getChildren: (row) ->
-    return @store.getChildren row
+    children = @store.getChildren row.id
+    _.each children, (child) ->
+      child.crumbs = { parent: row.id, crumbs: row.crumbs }
+    return children
 
   hasChildren: (row) ->
     return ((@getChildren row).length > 0)
 
   getSiblings: (row) ->
-    parent = @getParent row
-    return @getChildren parent
+    children = @store.getChildren row.crumbs.parent
+    _.each children, (child) ->
+      child.crumbs = row.crumbs
+    return children
 
   collapsed: (row) ->
-    return @store.getCollapsed row
+    return @store.getCollapsed row.id
 
-  toggleCollapsed: (id) ->
-    @store.setCollapsed id, (not @collapsed id)
+  canonicalInstance: (id) -> # Given an id (for example with search or mark), return a row with that id
+    # TODO: try to optimize for one in the viewroot
+    if id == @root.id
+      return @root
+    parent = (@store.getParents id)[0]
+    canonicalParent = @canonicalInstance parent.id
+    children = @getChildren canonicalParent
+    return _.find children, (sib) ->
+      sib.id == id
+
+  toggleCollapsed: (row) ->
+    @store.setCollapsed row.id, (not @collapsed row)
 
   # whether currently viewable.  ASSUMES ROW IS WITHIN VIEWROOT
   viewable: (row) ->
-    return (not @collapsed row) or (row == @viewRoot)
+    return (not @collapsed row) or (row.id == @viewRoot.id)
 
   indexOf: (child) ->
     children = @getSiblings child
-    return children.indexOf child
+    return _.findIndex children, (sib) ->
+        sib.id == child.id
 
-  detach: (id) ->
+  detach: (row) ->
     # detach a block from the graph
     # though it is detached, it remembers its old parent
     # and remembers its old mark
 
-    parent = @getParent id
-    children = @getChildren parent
-    i = children.indexOf id
-    children.splice i, 1
+    parent = @getParent row
+    children = @getSiblings row
+    ci = @indexOf row
+    children.splice ci, 1
+    parents = @getParents row
+    pi = _.findIndex parents, (par) ->
+        par.id == parent.id
+    parents.splice pi, 1
 
     @store.setChildren parent, children
+    @store.setParents row, parents
 
-    mark = @getMark id
+    mark = @getMark row
     if mark
       # set the mark in allMarks, but not for the row
       # that way, when re-attaching, we can try to re-apply the mark
-      @_updateAllMarks id, ''
+      @_updateAllMarks row, ''
 
     return {
       parent: parent
-      index: i
+      index: ci
     }
 
   # attaches a detached child to a parent
   # the child should not have a parent already
-  attachChild: (id, child, index = -1) ->
-    @attachChildren id, [child], index
+  attachChild: (row, child, index = -1) ->
+    @attachChildren row, [child], index
 
-  attachChildren: (id, new_children, index = -1) ->
-    children = @getChildren id
+  attachChildren: (row, new_children, index = -1) ->
+    children = @getChildren row
     if index == -1
       children.push.apply children, new_children
     else
       children.splice.apply children, [index, 0].concat(new_children)
     for child in new_children
-      @store.setParent child, id
+      child.crumbs = { parent: row.id, crumbs: row.crumbs }
+      parents = @store.getParents child.id
+      parents.push row.id
+      @store.setParents child.id, row.id
 
       # try to restore the mark of child
       mark = @getMark child
       if mark
         if not (@_updateAllMarks child, mark)
           # don't call @setMark, since that will mess up allMarks
-          @store.setMark child, ''
+          @store.setMark child.id, ''
 
-    @store.setChildren id, children
+    @store.setChildren row.id, children
 
-  nextVisible: (id = @viewRoot) ->
-    if @viewable id
-      children = @getChildren id
+  nextVisible: (row = @viewRoot) ->
+    if @viewable row
+      children = @getChildren row
       if children.length > 0
         return children[0]
     while true
-      nextsib = @getSiblingAfter id
+      nextsib = @getSiblingAfter row
       if nextsib != null
         return nextsib
-      id = @getParent id
-      if id == @viewRoot
+      row = @getParent row
+      if row.id == @viewRoot.id
         return null
 
   # last thing visible nested within id
-  lastVisible: (id = @viewRoot) ->
-    if not @viewable id
-      return id
-    children = @getChildren id
+  lastVisible: (row = @viewRoot) ->
+    if not @viewable row
+      return row
+    children = @getChildren row
     if children.length > 0
       return @lastVisible children[children.length - 1]
-    return id
+    return row
 
-  prevVisible: (id) ->
-    prevsib = @getSiblingBefore id
+  prevVisible: (row) ->
+    prevsib = @getSiblingBefore row
     if prevsib != null
       return @lastVisible prevsib
-    parent = @getParent id
-    if parent == @viewRoot
+    parent = @getParent row
+    if parent.id == @viewRoot.id
       return null
     return parent
 
   # finds oldest ancestor that is visible (viewRoot itself not considered visible)
   # returns null if there is no visible ancestor (i.e. viewroot doesn't contain row)
-  oldestVisibleAncestor: (id) ->
-    last = id
+  oldestVisibleAncestor: (row) ->
+    last = row
     while true
       cur = @getParent last
-      if cur == @viewRoot
+      if cur.id == @viewRoot.id
         return last
-      if cur == @root
+      if cur.id == @root.id
         return null
       last = cur
 
   # finds closest ancestor that is visible (viewRoot itself not considered visible)
   # returns null if there is no visible ancestor (i.e. viewroot doesn't contain row)
-  youngestVisibleAncestor: (id) ->
-    answer = id
-    cur = id
+  youngestVisibleAncestor: (row) ->
+    answer = row
+    cur = row
     while true
       cur = @getParent cur
-      if cur == @viewRoot
+      if cur.id == @viewRoot.id
         return answer
-      if cur == @root
+      if cur.id == @root.id
         return null
       if @collapsed cur
         answer = cur
 
   # returns whether a row is actually reachable from the root node
   # if something is not detached, it will have a parent, but the parent wont mention it as a child
-  isAttached: (id) ->
+  isAttached: (row) ->
+    # TODO: Refactor where this is used in light of cloning
     while true
-      if id == @root
+      if row.id == @root.id
         return true
-      if (@indexOf id) == -1
+      if (@indexOf row) == -1
         return false
-      id = @getParent id
+      row = @getParent row
 
-  getSiblingBefore: (id) ->
-    return @getSiblingOffset id, -1
+  getSiblingBefore: (row) ->
+    return @getSiblingOffset row, -1
 
-  getSiblingAfter: (id) ->
-    return @getSiblingOffset id, 1
+  getSiblingAfter: (row) ->
+    return @getSiblingOffset row, 1
 
-  getSiblingOffset: (id, offset) ->
-    return (@getSiblingRange id, offset, offset)[0]
+  getSiblingOffset: (row, offset) ->
+    return (@getSiblingRange row, offset, offset)[0]
 
-  getSiblingRange: (id, min_offset, max_offset) ->
-    children = @getSiblings id
-    index = @indexOf id
-    return @getChildRange (@getParent id), (min_offset + index), (max_offset + index)
+  getSiblingRange: (row, min_offset, max_offset) ->
+    children = @getSiblings row
+    index = @indexOf row
+    return @getChildRange (@getParent row), (min_offset + index), (max_offset + index)
 
-  getChildRange: (id, min, max) ->
-    children = @getChildren id
+  getChildRange: (row, min, max) ->
+    children = @getChildren row
     indices = [min..max]
 
     return indices.map (index) ->
@@ -283,14 +313,14 @@ class Data
       else
         return children[index]
 
-  addChild: (id, index = -1) ->
-    child = do @store.getNew
-    @attachChild id, child, index
+  addChild: (row, index = -1) ->
+    child = { id: do @store.getNew }
+    @attachChild row, child, index
     return child
 
   # this is never used, since data structure is basically persistent
   # deleteRow: (id) ->
-  #   if id == @viewRoot
+  #   if id == @viewRoot.id
   #     throw 'Cannot delete view root'
 
   #   for child in (@getChildren id).slice()
@@ -299,32 +329,32 @@ class Data
   #   @detach id
   #   @store.delete id
 
-  _insertSiblingHelper: (id, after) ->
-    if id == @viewRoot
+  _insertSiblingHelper: (row, after) ->
+    if row.id == @viewRoot.id
       Logger.logger.error 'Cannot insert sibling of view root'
       return null
 
-    parent = @getParent id
+    parent = @getParent row
     children = @getChildren parent
-    index = children.indexOf id
+    index = @indexOf row
 
     return (@addChild parent, (index + after))
 
-  insertSiblingAfter: (id) ->
-    return @_insertSiblingHelper id, 1
+  insertSiblingAfter: (row) ->
+    return @_insertSiblingHelper row, 1
 
-  insertSiblingBefore: (id) ->
-    return @_insertSiblingHelper id, 0
+  insertSiblingBefore: (row) ->
+    return @_insertSiblingHelper row, 0
 
   orderedLines: () ->
-    ids = []
+    rows = []
 
-    helper = (id) =>
-      ids.push id
-      for child in @getChildren id
+    helper = (row) =>
+      rows.push row
+      for child in @getChildren row
         helper child
     helper @root
-    return ids
+    return rows
 
   # find marks that start with the prefix
   findMarks: (prefix, nresults = 10) ->
@@ -359,8 +389,8 @@ class Data
     if query.length == 0
       return results
 
-    for id in do @orderedLines
-      line = canonicalize (@getText id).join ''
+    for row in do @orderedLines
+      line = canonicalize (@getText row).join ''
       matches = []
       if _.all(query_words.map ((word) ->
                 i = line.indexOf word
@@ -372,7 +402,7 @@ class Data
                   return false
               ))
         results.push {
-          row: id
+          row: row
           matches: matches
         }
       if nresults > 0 and results.length == nresults
@@ -384,14 +414,14 @@ class Data
   #################
 
   # important: serialized automatically garbage collects
-  serialize: (id = @root, pretty=false) ->
-    line = @getLine id
-    text = (@getText id).join('')
+  serialize: (row = @root, pretty=false) ->
+    line = @getLine row
+    text = (@getText row).join('')
 
     struct = {
       text: text
     }
-    children = (@serialize childid, pretty for childid in @getChildren id)
+    children = (@serialize childrow, pretty for childrow in @getChildren row)
     if children.length
       struct.children = children
 
@@ -400,13 +430,13 @@ class Data
         struct[property] = ((if obj[property] then '.' else ' ') for obj in line).join ''
         pretty = false
 
-    if id == @root and @viewRoot != @root
+    if row.id == @root.id and @viewRoot.id != @root.id
       struct.viewRoot = @viewRoot
 
-    if @collapsed id
+    if @collapsed row
       struct.collapsed = true
 
-    mark = @store.getMark id
+    mark = @store.getMark row
     if mark
       struct.mark = mark
 
@@ -416,16 +446,17 @@ class Data
     return struct
 
   loadTo: (serialized, parent = @root, index = -1) ->
-    id = do @store.getNew
+    row = { id: do @store.getNew }
 
-    if id != @root
-      @attachChild parent, id, index
+    if row.id != @root.id
+      @attachChild parent, row, index
     else
-      # parent should be 0
-      @store.setParent id, @root
+      # parent should be 0 == @root.id
+      @store.setParents row.id, [@root.id]
+      row.crumbs = @root.crumbs
 
     if typeof serialized == 'string'
-      @setLine id, (serialized.split '')
+      @setLine row, (serialized.split '')
     else
       line = (serialized.text.split '').map((char) -> {char: char})
       for property in constants.text_properties
@@ -434,17 +465,17 @@ class Data
             if val == '.'
               line[i][property] = true
 
-      @setLine id, line
-      @store.setCollapsed id, serialized.collapsed
+      @setLine row, line
+      @store.setCollapsed row.id, serialized.collapsed
 
       if serialized.mark
-        @setMark id, serialized.mark
+        @setMark row, serialized.mark
 
       if serialized.children
         for serialized_child in serialized.children
-          @loadTo serialized_child, id
+          @loadTo serialized_child, row
 
-    return id
+    return row
 
   load: (serialized) ->
     if serialized.viewRoot

--- a/assets/js/datastore.coffee
+++ b/assets/js/datastore.coffee
@@ -12,9 +12,9 @@ if module?
       throw 'Not implemented'
     setLine: (row, line) ->
       throw 'Not implemented'
-    getParent: (row) ->
+    getParents: (row) ->
       throw 'Not implemented'
-    setParent: (row, parent) ->
+    setParents: (row, parent) ->
       throw 'Not implemented'
     getChildren: (row) ->
       throw 'Not implemented'
@@ -77,11 +77,14 @@ if module?
     setLine: (row, line) ->
       @lines[row] = line
 
-    getParent: (row) ->
-      return @parents[row]
+    getParents: (row) ->
+      parents = @parents[row]
+      if typeof parents == 'number' then parents = [parents]
+      unless parents? then parents = []
+      return parents
 
-    setParent: (row, parent) ->
-      @parents[row] = parent
+    setParents: (row, parents) ->
+      @parents[row] = parents
 
     getChildren: (row) ->
       return [].slice.apply @children[row]
@@ -111,7 +114,7 @@ if module?
       return # no point in remembering
 
     getLastViewRoot: () ->
-      return 0
+      return
 
     getAllMarks: () ->
       return _.clone @allMarks
@@ -199,14 +202,17 @@ if module?
       @lines[row] = line
       @_setLocalStorage_ (@_lineKey_ row), line
 
-    getParent: (row) ->
+    getParents: (row) ->
       if not (row of @parents)
         @parents[row] = @_getLocalStorage_ @_parentKey_ row
-      return @parents[row]
+      parents = @parents[row]
+      if typeof parents == 'number' then parents = [parents]
+      unless parents? then parents = []
+      return parents
 
-    setParent: (row, parent) ->
-      @parents[row] = parent
-      @_setLocalStorage_ (@_parentKey_ row), parent
+    setParents: (row, parents) ->
+      @parents[row] = parents
+      @_setLocalStorage_ (@_parentKey_ row), parents
 
     getChildren: (row) ->
       if not (row of @children)
@@ -255,10 +261,10 @@ if module?
       return @_setLocalStorage_ @_allMarksKey_, marks
 
     getLastViewRoot: () ->
-      id = @_getLocalStorage_ @_lastViewrootKey_ , 0
+      id = @_getLocalStorage_ @_lastViewrootKey_
       if (localStorage.getItem @_lineKey_ id) == null
         Logger.logger.error 'Invalid view root', id
-        id = 0
+        return
       return id
 
     getId: () ->

--- a/assets/js/datastore.coffee
+++ b/assets/js/datastore.coffee
@@ -1,5 +1,5 @@
 if module?
-  _ = require('underscore')
+  _ = require('lodash')
   Logger = require('./logger.coffee')
 
 ((exports) ->

--- a/assets/js/keyBindings.coffee
+++ b/assets/js/keyBindings.coffee
@@ -50,6 +50,7 @@ if module?
     CHANGE_CHAR       : ['s']
     REPLACE           : ['r']
     YANK              : ['y']
+    #CLONE             : ['c']
     PASTE_AFTER       : ['p']
     PASTE_BEFORE      : ['P']
     JOIN_LINE         : ['J']
@@ -342,6 +343,7 @@ if module?
   #   if this is a motion, takes an extra cursor argument first
   # continue:
   #   a function which takes next key
+  # TODO: document 'drop'
   # bindings:
   #   a dictionary from keyDefinitions to functions
   #   *SPECIAL KEYS*
@@ -773,6 +775,12 @@ if module?
           finishes_visual: true
           fn: (cursor, options = {}) ->
             @view.yankBetween @view.cursor, cursor, options
+        #CLONE:
+        #  display: 'Yank blocks as a clone'
+        #  drop: true # TODO: Is this correct? Re-check after Jeff documents
+        #  finishes_visual_line: true
+        #  fn: () ->
+        #    @view.yankBlocksClone @repeat
     PASTE_AFTER:
       display: 'Paste after cursor'
       fn: () ->

--- a/assets/js/keyBindings.coffee
+++ b/assets/js/keyBindings.coffee
@@ -50,7 +50,7 @@ if module?
     CHANGE_CHAR       : ['s']
     REPLACE           : ['r']
     YANK              : ['y']
-    #CLONE             : ['c']
+    CLONE             : ['c']
     PASTE_AFTER       : ['p']
     PASTE_BEFORE      : ['P']
     JOIN_LINE         : ['J']
@@ -175,7 +175,8 @@ if module?
     'CHANGE', 'CHANGE_CHAR',
     'DELETE_TO_HOME', 'DELETE_TO_END', 'DELETE_LAST_CHAR', 'DELETE_LAST_WORD'
     'REPLACE',
-    'YANK', 'PASTE_AFTER', 'PASTE_BEFORE',
+    'YANK', 'CLONE',
+    'PASTE_AFTER', 'PASTE_BEFORE',
     'JOIN_LINE', 'SPLIT_LINE',
 
     'INDENT_RIGHT', 'INDENT_LEFT',
@@ -775,12 +776,12 @@ if module?
           finishes_visual: true
           fn: (cursor, options = {}) ->
             @view.yankBetween @view.cursor, cursor, options
-        #CLONE:
-        #  display: 'Yank blocks as a clone'
-        #  drop: true # TODO: Is this correct? Re-check after Jeff documents
-        #  finishes_visual_line: true
-        #  fn: () ->
-        #    @view.yankBlocksClone @repeat
+        CLONE:
+          display: 'Yank blocks as a clone'
+          drop: true # TODO: Is this correct? Re-check after Jeff documents
+          finishes_visual_line: true
+          fn: () ->
+            @view.yankBlocksClone @repeat
     PASTE_AFTER:
       display: 'Paste after cursor'
       fn: () ->

--- a/assets/js/keyBindings.coffee
+++ b/assets/js/keyBindings.coffee
@@ -1,6 +1,6 @@
 # imports
 if module?
-  _ = require('underscore')
+  _ = require('lodash')
   constants = require('./constants.coffee')
 
 ((exports) ->

--- a/assets/js/register.coffee
+++ b/assets/js/register.coffee
@@ -60,8 +60,7 @@ class Register
     else if @type == Register.TYPES.SERIALIZED_ROWS
       @pasteSerializedRows options
     else if @type == Register.TYPES.CLONED_ROWS
-      #TODO: Implement
-      console.log "CLONED_ROWS paste from register is not implemented"
+      @pasteClonedRows options
 
   pasteChars: (options = {}) ->
     if options.before
@@ -102,6 +101,20 @@ class Register
         @view.addBlocks @serialized_rows, row, 0, {setCursor: 'first'}
       else
         @view.addBlocks @serialized_rows, parent, (index + 1), {setCursor: 'first'}
+
+  pasteClonedRows: (options = {}) ->
+    row = @view.cursor.row
+    parent = @view.data.getParent row
+    index = @view.data.indexOf row
+
+    if options.before
+      @view.addClones @cloned_rows, parent, index, {setCursor: 'first'}
+    else
+      children = @view.data.getChildren row
+      if (not @view.data.collapsed row) and (children.length > 0)
+        @view.addClones @cloned_rows, row, 0, {setCursor: 'first'}
+      else
+        @view.addClones @cloned_rows, parent, (index + 1), {setCursor: 'first'}
 
 # exports
 module?.exports = Register

--- a/assets/js/register.coffee
+++ b/assets/js/register.coffee
@@ -1,84 +1,107 @@
 class Register
+
+  #############
+  # Union Type 
+  #############
+
   @TYPES = {
     NONE: 0
     CHARS: 1
+    # TODO: Document difference between ROWS and SERIALIZED ROWS
     ROWS: 2
     SERIALIZED_ROWS: 3
+    CLONED_ROWS: 4
   }
 
   constructor: (view) ->
     @view = view
-    @type = Register.TYPES.NONE
+    do @saveNone
     return @
 
-  saveChars: (chars) ->
+  saveNone: () ->
+    @type = Register.TYPES.NONE
+    @data = ''
+  saveChars: (data) ->
     @type = Register.TYPES.CHARS
-    @chars = chars
-
-  saveSerializedRows: (serialized_rows) ->
-    @type = Register.TYPES.SERIALIZED_ROWS
-    @serialized_rows = serialized_rows
-
-  saveRows: (rows) ->
+    @data = data
+  saveRows: (data) ->
     @type = Register.TYPES.ROWS
-    @rows = rows
+    @data = data
+  saveSerializedRows: (data) ->
+    @type = Register.TYPES.SERIALIZED_ROWS
+    @data = data
+  saveClonedRows: (data) ->
+    @type = Register.TYPES.CLONED_ROWS
+    @data = data
+  
+  # Register is a union type. @data holds one of several values
+  # They can be referenced as @rows etc.
+  for type of Register.TYPES
+    Object.defineProperty @prototype, type.toLowerCase(),
+        get: -> @data
+        set: (data) -> @data = data
 
   serialize: () ->
-    data = ''
-    if @type == Register.TYPES.CHARS
-      data = @chars
-    else if @type == Register.TYPES.ROWS
-      data = [@view.data.serialize row for row in @rows]
-    else if @type == Register.TYPES.SERIALIZED_ROWS
-      data = @serialized_rows
-    return {type: @type, data: data}
+    return {type: @type, data: @data}
 
   deserialize: (serialized) ->
     @type = serialized.type
-    if @type == Register.TYPES.CHARS
-      @chars = serialized.data
-    else if @type == Register.TYPES.ROWS
-      @serialized_rows = serialized.data
-    else if @type == Register.TYPES.SERIALIZED_ROWS
-      @serialized_rows = serialized.data
+    @data = serialized.data
+
+  ###########
+  # Register 
+  ###########
 
   paste: (options = {}) ->
     if @type == Register.TYPES.CHARS
-      if options.before
-        @view.addCharsAtCursor @chars, {cursor: options.cursor}
-      else
-        @view.addCharsAfterCursor @chars, {setCursor: 'end', cursor: options.cursor}
+      @pasteChars options
     else if @type == Register.TYPES.ROWS
-      # now that rows are in action, must switch to serialized version
-      @saveSerializedRows (@view.data.serialize row for row in @rows)
-
-      row = @view.cursor.row
-      parent = @view.data.getParent row
-      index = @view.data.indexOf row
-
-      if options.before
-        @view.attachBlocks @rows, parent, index
-      else
-        children = @view.data.getChildren row
-        if (not @view.data.collapsed row) and (children.length > 0)
-          @view.attachBlocks @rows, row, 0
-        else
-          @view.attachBlocks @rows ,parent, (index + 1)
-
-      @view.cursor.set @rows[0], 0
+      @pasteRows options
     else if @type == Register.TYPES.SERIALIZED_ROWS
-      row = @view.cursor.row
-      parent = @view.data.getParent row
-      index = @view.data.indexOf row
+      @pasteSerializedRows options
+    else if @type == Register.TYPES.CLONED_ROWS
+      #TODO: Implement
+      console.log "CLONED_ROWS paste from register is not implemented"
 
-      if options.before
-        @view.addBlocks @serialized_rows, parent, index, {setCursor: 'first'}
+  pasteChars: (options = {}) ->
+    if options.before
+      @view.addCharsAtCursor @chars, {cursor: options.cursor}
+    else
+      @view.addCharsAfterCursor @chars, {setCursor: 'end', cursor: options.cursor}
+
+  pasteRows: (options = {}) ->
+    # now that rows are in action, must switch to serialized version
+    rows = @rows
+    @saveSerializedRows (@view.data.serialize row for row in @rows)
+
+    row = @view.cursor.row
+    parent = @view.data.getParent row
+    index = @view.data.indexOf row
+
+    if options.before
+      @view.attachBlocks rows, parent, index
+    else
+      children = @view.data.getChildren row
+      if (not @view.data.collapsed row) and (children.length > 0)
+        @view.attachBlocks rows, row, 0
       else
-        children = @view.data.getChildren row
-        if (not @view.data.collapsed row) and (children.length > 0)
-          @view.addBlocks @serialized_rows, row, 0, {setCursor: 'first'}
-        else
-          @view.addBlocks @serialized_rows ,parent, (index + 1), {setCursor: 'first'}
+        @view.attachBlocks rows, parent, (index + 1)
+
+    @view.cursor.set rows[0], 0
+
+   pasteSerializedRows: (options = {}) ->
+    row = @view.cursor.row
+    parent = @view.data.getParent row
+    index = @view.data.indexOf row
+
+    if options.before
+      @view.addBlocks @serialized_rows, parent, index, {setCursor: 'first'}
+    else
+      children = @view.data.getChildren row
+      if (not @view.data.collapsed row) and (children.length > 0)
+        @view.addBlocks @serialized_rows, row, 0, {setCursor: 'first'}
+      else
+        @view.addBlocks @serialized_rows, parent, (index + 1), {setCursor: 'first'}
 
 # exports
 module?.exports = Register

--- a/assets/js/view.coffee
+++ b/assets/js/view.coffee
@@ -872,25 +872,25 @@ renderLine = (lineData, options = {}) ->
       @detachBlock row, options
       @attachBlock row, parent, index, options
 
-    indentBlocks: (id, numblocks = 1) ->
-      newparent = @data.getSiblingBefore id
+    indentBlocks: (row, numblocks = 1) ->
+      newparent = @data.getSiblingBefore row
       if newparent == null
         return null # cannot indent
 
       if @data.collapsed newparent
         @toggleBlock newparent
 
-      siblings = @data.getSiblingRange id, 0, (numblocks-1)
+      siblings = @data.getSiblingRange row, 0, (numblocks-1)
       for sib in siblings
         @moveBlock sib, newparent, -1
       return newparent
 
-    unindentBlocks: (id, numblocks = 1, options = {}) ->
-      parent = @data.getParent id
-      if parent == @data.viewRoot
+    unindentBlocks: (row, numblocks = 1, options = {}) ->
+      parent = @data.getParent row
+      if parent.id == @data.viewRoot.id
         return null
 
-      siblings = @data.getSiblingRange id, 0, (numblocks-1)
+      siblings = @data.getSiblingRange row, 0, (numblocks-1)
 
       newparent = @data.getParent parent
       pp_i = @data.indexOf parent

--- a/assets/js/view.coffee
+++ b/assets/js/view.coffee
@@ -1140,7 +1140,7 @@ renderLine = (lineData, options = {}) ->
       cursors = {}
       highlights = {}
 
-      marking = @markrow == row
+      marking = @markrow?.id == row.id
 
       if row == @cursor.row and not marking
         cursors[@cursor.col] = true

--- a/assets/js/view.coffee
+++ b/assets/js/view.coffee
@@ -1,6 +1,6 @@
 # imports
 if module?
-  _ = require('underscore')
+  _ = require('lodash')
 
   actions = require('./actions.coffee')
   constants = require('./constants.coffee')
@@ -1097,7 +1097,7 @@ renderLine = (lineData, options = {}) ->
 
       marking = @markrow?.id == row.id
 
-      if row == @cursor.row and not marking
+      if (data.sameInstance row, @cursor.row) and not marking
         cursors[@cursor.col] = true
 
         if @anchor and not @lineSelect

--- a/assets/js/view.coffee
+++ b/assets/js/view.coffee
@@ -787,11 +787,18 @@ renderLine = (lineData, options = {}) ->
       action = new actions.AddBlocks serialized_rows, parent, index, options
       @act action
 
+    addClones: (cloned_rows, parent, index = -1, options = {}) ->
+      action = new actions.CloneBlocks cloned_rows, parent, index, options
+      @act action
+
     yankBlocks: (nrows) ->
       siblings = @data.getSiblingRange @cursor.row, 0, (nrows-1)
-      siblings = siblings.filter ((x) -> return x != null)
       serialized = siblings.map ((x) => return @data.serialize x)
       @register.saveSerializedRows serialized
+
+    yankBlocksClone: (nrows) ->
+      siblings = @data.getSiblingRange @cursor.row, 0, (nrows-1)
+      @register.saveClonedRows (siblings.map (sibling) -> sibling.id)
 
     detachBlock: (row, options = {}) ->
       action = new actions.DetachBlock row, options

--- a/assets/js/view.coffee
+++ b/assets/js/view.coffee
@@ -1041,7 +1041,7 @@ renderLine = (lineData, options = {}) ->
     virtualRender: (options = {}) ->
       crumbs = []
       row = @data.viewRoot
-      while row != @data.root
+      while row.id != @data.root.id
         crumbs.push row
         row = @data.getParent row
 

--- a/assets/js/view.coffee
+++ b/assets/js/view.coffee
@@ -571,7 +571,7 @@ renderLine = (lineData, options = {}) ->
 
     # try going to jump, return true if succeeds
     tryJump: (jump) ->
-      if jump.viewRoot == @data.viewRoot
+      if jump.viewRoot.id == @data.viewRoot.id
         return false # not moving, don't jump
 
       if not @data.isAttached jump.viewRoot

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "connect-flash": "latest",
     "express": "latest",
     "jade": "latest",
+    "lodash": "latest",
     "nodemon": "latest",
-    "node-sass": "latest",
-    "underscore": "latest"
+    "node-sass": "latest"
   }
 }

--- a/public/lodash.js
+++ b/public/lodash.js
@@ -1,0 +1,1 @@
+../node_modules/lodash/index.js

--- a/public/underscore-min.js
+++ b/public/underscore-min.js
@@ -1,1 +1,0 @@
-../node_modules/underscore/underscore-min.js

--- a/tests/testcase.coffee
+++ b/tests/testcase.coffee
@@ -44,11 +44,11 @@ class TestCase
     return @
 
   expectViewRoot: (expected) ->
-    assert.equal @data.viewRoot, expected
+    assert.equal @data.viewRoot.id, expected
     return @
 
   expectCursor: (row, col) ->
-    assert.equal @view.cursor.row, row
+    assert.equal @view.cursor.row.id, row
     assert.equal @view.cursor.col, col
     return @
 

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -13,7 +13,7 @@ html
 
     script(src='/jquery-2.1.1.min.js')
     script(src='/jquery.cookie.min.js')
-    script(src='/underscore-min.js')
+    script(src='/lodash.js')
     script(src='/virtual-dom.js')
     != js('app.js')
     block morefoot


### PR DESCRIPTION
Switched over from having only the concept of "nodes", to having both "nodes" and "instances". No other changes, aliasing is not actually added yet.

An instance is a client-side-only concept, it is never written to the datastore. lastViewRoot does contain information about an instance, but the datastore now treats this as an opaque token with no default value.

An instance looks like

    {
      id: <node-id>,
      crumbs: { 
        parent: <parent-node-id>,
        crumbs: <further-ancestors>
      }
    }

For example,

    {
     id: 3,
      crumbs: { 
        parent: 2,
        crumbs: { parent: 1, crumbs: { parent: 0 } }
      }
    }