### PR TITLE
update urlRegex to match localhost

### DIFF
--- a/assets/js/utils.coffee
+++ b/assets/js/utils.coffee
@@ -11,7 +11,7 @@ exports.isWhitespace = (char) ->
 exports.isPunctuation = (char) ->
   return char == '.' or char == ',' or char == '!' or char == '?'
 
-urlRegex = /^https?:\/\/[^\s]+\.[^\s]+$/
+urlRegex = /^https?:\/\/([^\s]+\.[^\s]+$|localhost)/
 exports.isLink = (word) ->
   return urlRegex.test word
 


### PR DESCRIPTION
This PR adjusts the `urlRegex` to also match `localhost` urls. If a vimflowy doc includes the text `http://localhost:8080/other-vimflowy-doc`, the text will now display as a link.

A simpler alternative would be `urlRegex = /^https?:\/\/[^\s]+$/` which would no longer require matches to have a dot (sometimes the case with internal urls?). But maybe that would cause trouble.