### PR TITLE
set export filename to docname

### DIFF
--- a/assets/js/index.coffee
+++ b/assets/js/index.coffee
@@ -252,7 +252,7 @@ create_session = (doc, to_load) ->
 
     export_type = (type) ->
       session.showMessage 'Exporting...'
-      filename = 'vimflowy.' + type
+      filename = if docname is '' then "vimflowy.#{type}" else "#{docname}.#{type}"
       # Infer mimetype from file extension
       mimetype = utils.mimetypeLookup filename
       content = session.exportContent mimetype


### PR DESCRIPTION
It seems nice if `http://localhost:8080/somedocumentname` exports to `somedocumentname.json`, instead of all documents exporting to `vimflowy.json`. See what you think.