### PR TITLE
Swapping case

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint": "tslint --exclude 'node_modules/**/*' '**/*.ts' '**/*.tsx' && eslint --ignore-path .gitignore .",
     "start": "node dev_server.js",
     "test": "mocha --opts test/mocha.opts",
-    "typecheck": "tsc -p . --noEmit"
+    "typecheck": "tsc -p . --noEmit",
+    "verify": "npm run lint && npm run typecheck && npm test"
   },
   "dependencies": {
     "@types/immutable": "^3.8.4",

--- a/src/assets/js/components/session.tsx
+++ b/src/assets/js/components/session.tsx
@@ -92,10 +92,8 @@ export default class SessionComponent extends React.Component<Props, State> {
         return () => () => null;
       }
 
-      let t0 = Date.now();
-
       return (profilerMessage) => {
-        t0 = Date.now();
+        const t0 = Date.now();
 
         return () => {
           logger.info(profilerMessage, Date.now() - t0);
@@ -152,7 +150,7 @@ export default class SessionComponent extends React.Component<Props, State> {
 
   private async fetchAndRerender() {
     const session = this.props.session;
-    const finishProfiling = this.getProfiler(this.profileRender)('Update took');
+    const finishProfiling = this.getProfiler(this.profileRender)('forceLoadTree took');
 
     await session.document.forceLoadTree(session.viewRoot.row, true);
 

--- a/src/assets/js/configurations/vim.ts
+++ b/src/assets/js/configurations/vim.ts
@@ -139,6 +139,7 @@ export const VISUAL_MODE_MAPPINGS: HotkeyMapping = Object.assign({
   'visual-toggle-italic': [['ctrl+I']],
   'visual-toggle-underline': [['ctrl+U']],
   'visual-toggle-strikethrough': [['ctrl+enter']],
+  'visual-swap-case': [['~']],
 }, _.pick(NORMAL_MOTION_MAPPINGS, SINGLE_LINE_MOTIONS));
 
 export const VISUAL_LINE_MODE_MAPPINGS: HotkeyMapping = Object.assign({

--- a/src/assets/js/configurations/vim.ts
+++ b/src/assets/js/configurations/vim.ts
@@ -124,6 +124,7 @@ export const NORMAL_MODE_MAPPINGS: HotkeyMapping = Object.assign({
   'zoom-root': [['shift+enter'], ['ctrl+shift+left']],
   'jump-prev': [['ctrl+o']],
   'jump-next': [['ctrl+i']],
+  'swap-case': [['~']],
 }, NORMAL_MOTION_MAPPINGS);
 
 export const VISUAL_MODE_MAPPINGS: HotkeyMapping = Object.assign({

--- a/src/assets/js/configurations/vim.ts
+++ b/src/assets/js/configurations/vim.ts
@@ -158,6 +158,7 @@ export const VISUAL_LINE_MODE_MAPPINGS: HotkeyMapping = Object.assign({
   'visual-line-toggle-underline': [['ctrl+U']],
   'visual-line-toggle-strikethrough': [['ctrl+enter']],
   'toggle-row-strikethrough': [['meta+enter']],
+  'visual-line-swap-case': [['~']],
 }, NORMAL_MOTION_MAPPINGS);
 
 export const INSERT_MODE_MAPPINGS: HotkeyMapping = Object.assign({

--- a/src/assets/js/definitions/basics.ts
+++ b/src/assets/js/definitions/basics.ts
@@ -544,3 +544,12 @@ keyDefinitions.registerAction(new Action(
     await session.swapCaseAtCursor();
   }
 ));
+
+keyDefinitions.registerAction(new Action(
+  'visual-swap-case',
+  'Swap case in VISUAL mode',
+  async function({ session }) {
+    await session.swapCaseInVisual(session.cursor, session.anchor);
+    await session.setMode('NORMAL');
+  }
+));

--- a/src/assets/js/definitions/basics.ts
+++ b/src/assets/js/definitions/basics.ts
@@ -536,7 +536,6 @@ keyDefinitions.registerAction(new Action(
   },
 ));
 
-// swapping case
 keyDefinitions.registerAction(new Action(
   'swap-case',
   'Swap case',

--- a/src/assets/js/definitions/basics.ts
+++ b/src/assets/js/definitions/basics.ts
@@ -535,3 +535,12 @@ keyDefinitions.registerAction(new Action(
     await session.cursor.from(tmp);
   },
 ));
+
+// swapping case
+keyDefinitions.registerAction(new Action(
+  'swap-case',
+  'Swap case',
+  async function({ session }) {
+    await session.swapCaseAtCursor();
+  }
+));

--- a/src/assets/js/definitions/basics.ts
+++ b/src/assets/js/definitions/basics.ts
@@ -1,5 +1,5 @@
 import * as utils from '../utils';
-import keyDefinitions, { Action, SequenceAction } from '../keyDefinitions';
+import keyDefinitions, { Action, ActionContext, SequenceAction } from '../keyDefinitions';
 
 keyDefinitions.registerAction(new Action(
   'move-cursor-normal',
@@ -542,7 +542,7 @@ keyDefinitions.registerAction(new Action(
   'Swap case',
   async function({ session }) {
     await session.swapCaseAtCursor();
-  }
+  },
 ));
 
 keyDefinitions.registerAction(new Action(
@@ -551,5 +551,24 @@ keyDefinitions.registerAction(new Action(
   async function({ session }) {
     await session.swapCaseInVisual(session.cursor, session.anchor);
     await session.setMode('NORMAL');
-  }
+  },
+));
+
+keyDefinitions.registerAction(new Action(
+  'visual-line-swap-case',
+  'Swap case in VISUAL_LINE mode',
+  async function({ session, visual_line }: ActionContext) {
+    if (visual_line == null) {
+      throw new Error('Visual_line mode arguments missing');
+    }
+
+    const rows = (await session.document.getChildRange(
+      visual_line.parent, visual_line.start_i, visual_line.end_i
+    )).map(path => {
+      return path.row;
+    });
+
+    await session.swapCaseInVisualLine(rows);
+    await session.setMode('NORMAL');
+  },
 ));

--- a/src/assets/js/session.ts
+++ b/src/assets/js/session.ts
@@ -86,6 +86,13 @@ export default class Session extends EventEmitter {
   public toggleBindingsDiv: () => void;
   private downloadFile: (filename: string, mimetype: string, content: any) => void;
 
+  private static swapCase(chars: Chars) {
+    return chars.map(function(char_obj) {
+      const new_char = _.clone(char_obj);
+      new_char.char = char_obj.char.toLowerCase() === char_obj.char ? char_obj.char.toUpperCase() : char_obj.char.toLowerCase();
+      return new_char;
+    });
+  }
   constructor(doc: Document, options: SessionOptions = {}) {
     super();
 
@@ -775,16 +782,8 @@ export default class Session extends EventEmitter {
     return mutation.ncharsDeleted;
   }
 
-  private static swapCase(chars: Chars) {
-    return chars.map(function(char_obj) {
-      const new_char = _.clone(char_obj);
-      new_char.char = char_obj.char.toLowerCase() === char_obj.char ? char_obj.char.toUpperCase() : char_obj.char.toLowerCase();
-      return new_char;
-    });
-  }
-
   public async swapCaseAtCursor() {
-    await this.changeChars(this.cursor.row, this.cursor.col, 1, this.swapCase);
+    await this.changeChars(this.cursor.row, this.cursor.col, 1, Session.swapCase);
     await this.cursor.right();
   }
 
@@ -799,7 +798,7 @@ export default class Session extends EventEmitter {
     }
 
     const nchars = cursor2.col - cursor1.col + 1;
-    await this.changeChars(cursor1.row, cursor1.col, nchars, this.swapCase);
+    await this.changeChars(cursor1.row, cursor1.col, nchars, Session.swapCase);
     await this.cursor.from(cursor1);
   }
 
@@ -808,7 +807,7 @@ export default class Session extends EventEmitter {
       row,
       0,
       await this.document.getLength(row),
-      this.swapCase
+      Session.swapCase
     )));
   }
 
@@ -1424,5 +1423,4 @@ export default class Session extends EventEmitter {
 
     this.emit('scroll', numlines);
   }
-
 }

--- a/src/assets/js/session.ts
+++ b/src/assets/js/session.ts
@@ -775,15 +775,32 @@ export default class Session extends EventEmitter {
     return mutation.ncharsDeleted;
   }
 
+  private swapCase(chars: Chars) {
+    return chars.map(function(char_obj) {
+      const new_char = _.clone(char_obj);
+      new_char.char = char_obj.char.toLowerCase() === char_obj.char ? char_obj.char.toUpperCase() : char_obj.char.toLowerCase();
+      return new_char;
+    });
+  }
+
   public async swapCaseAtCursor() {
-    await this.changeChars(this.cursor.row, this.cursor.col, 1, (chars => 
-      chars.map(function(char_obj) {
-        const new_char = _.clone(char_obj);
-        new_char.char = char_obj.char.toLowerCase() === char_obj.char ? char_obj.char.toUpperCase() : char_obj.char.toLowerCase();
-        return new_char;
-      })
-    ));
+    await this.changeChars(this.cursor.row, this.cursor.col, 1, this.swapCase);
     await this.cursor.right();
+  }
+
+  public async swapCaseInVisual(cursor1: Cursor, cursor2: Cursor) {
+    if (!(cursor2.path.is(cursor1.path))) {
+      logger.warn('Not yet implemented');
+      return;
+    }
+
+    if (cursor2.col < cursor1.col) {
+      [cursor1, cursor2] = [cursor2, cursor1];
+    }
+
+    const howManyCharacters = cursor2.col - cursor1.col + 1;
+    await this.changeChars(cursor1.row, cursor1.col, howManyCharacters, this.swapCase);
+    await this.cursor.from(cursor1);
   }
 
   public async replaceCharsAfterCursor(char: string, nchars: number) {

--- a/src/assets/js/session.ts
+++ b/src/assets/js/session.ts
@@ -775,7 +775,7 @@ export default class Session extends EventEmitter {
     return mutation.ncharsDeleted;
   }
 
-  private swapCase(chars: Chars) {
+  private static swapCase(chars: Chars) {
     return chars.map(function(char_obj) {
       const new_char = _.clone(char_obj);
       new_char.char = char_obj.char.toLowerCase() === char_obj.char ? char_obj.char.toUpperCase() : char_obj.char.toLowerCase();
@@ -798,8 +798,8 @@ export default class Session extends EventEmitter {
       [cursor1, cursor2] = [cursor2, cursor1];
     }
 
-    const howManyCharacters = cursor2.col - cursor1.col + 1;
-    await this.changeChars(cursor1.row, cursor1.col, howManyCharacters, this.swapCase);
+    const nchars = cursor2.col - cursor1.col + 1;
+    await this.changeChars(cursor1.row, cursor1.col, nchars, this.swapCase);
     await this.cursor.from(cursor1);
   }
 

--- a/src/assets/js/session.ts
+++ b/src/assets/js/session.ts
@@ -803,6 +803,24 @@ export default class Session extends EventEmitter {
     await this.cursor.from(cursor1);
   }
 
+  public async swapCaseInVisualLine(rows: Array<Row>) {
+    const linesWithRows = await Promise.all(rows.map(async row => {
+      return {
+        line: await this.document.getLine(row),
+        row: row
+      };
+    }));
+
+    const caseSwappedLinesWithRows = linesWithRows.map(l => {
+      return {
+        line: this.swapCase(l.line),
+        row: l.row
+      };
+    });
+
+    await Promise.all(caseSwappedLinesWithRows.map(async swapped => await this.document.setLine(swapped.row, swapped.line)));
+  }
+
   public async replaceCharsAfterCursor(char: string, nchars: number) {
     const ndeleted = await this.changeChars(this.cursor.row, this.cursor.col, nchars, (chars =>
       chars.map(function(char_obj) {

--- a/src/assets/js/session.ts
+++ b/src/assets/js/session.ts
@@ -775,6 +775,17 @@ export default class Session extends EventEmitter {
     return mutation.ncharsDeleted;
   }
 
+  public async swapCaseAtCursor() {
+    await this.changeChars(this.cursor.row, this.cursor.col, 1, (chars => 
+      chars.map(function(char_obj) {
+        const new_char = _.clone(char_obj);
+        new_char.char = char_obj.char.toLowerCase() === char_obj.char ? char_obj.char.toUpperCase() : char_obj.char.toLowerCase();
+        return new_char;
+      })
+    ));
+    await this.cursor.right();
+  }
+
   public async replaceCharsAfterCursor(char: string, nchars: number) {
     const ndeleted = await this.changeChars(this.cursor.row, this.cursor.col, nchars, (chars =>
       chars.map(function(char_obj) {

--- a/src/assets/js/session.ts
+++ b/src/assets/js/session.ts
@@ -804,21 +804,12 @@ export default class Session extends EventEmitter {
   }
 
   public async swapCaseInVisualLine(rows: Array<Row>) {
-    const linesWithRows = await Promise.all(rows.map(async row => {
-      return {
-        line: await this.document.getLine(row),
-        row: row
-      };
-    }));
-
-    const caseSwappedLinesWithRows = linesWithRows.map(l => {
-      return {
-        line: this.swapCase(l.line),
-        row: l.row
-      };
-    });
-
-    await Promise.all(caseSwappedLinesWithRows.map(async swapped => await this.document.setLine(swapped.row, swapped.line)));
+    await Promise.all(rows.map(async row => await this.changeChars(
+      row,
+      0,
+      await this.document.getLength(row),
+      this.swapCase
+    )));
   }
 
   public async replaceCharsAfterCursor(char: string, nchars: number) {

--- a/test/tests/swap_case.ts
+++ b/test/tests/swap_case.ts
@@ -1,0 +1,22 @@
+/* globals describe, it */
+import TestCase from '../testcase';
+// import { RegisterTypes } from '../../src/assets/js/register';
+
+describe.only('swapping case', function() {
+  it('should swap case at cursor and moving cursor to the right', async function() {
+    let t = new TestCase(['oo']);
+    t.sendKeys('0');
+    t.sendKey('~');
+    t.expect(['Oo']);
+    t.expectCursor(1, 1);
+    await t.done();
+  });
+
+  it('should not move cursor if swapping at the end of line', async function() {
+    let t = new TestCase(['oo']);
+    t.sendKeys('$~');
+    t.expect(['oO']);
+    t.expectCursor(1,1);
+    await t.done();
+  })
+});

--- a/test/tests/swap_case.ts
+++ b/test/tests/swap_case.ts
@@ -1,9 +1,9 @@
 /* globals describe, it */
 import TestCase from '../testcase';
 
-describe.only('swapping case', function() {
+describe('swapping case', function() {
   it('should swap case at cursor and moving cursor to the right', async function() {
-    let t = new TestCase(['oo']);
+    const t = new TestCase(['oo']);
     t.sendKeys('0');
     t.sendKey('~');
     t.expect(['Oo']);
@@ -18,7 +18,7 @@ describe.only('swapping case', function() {
   });
 
   it('should not move cursor if swapping at the end of line', async function() {
-    let t = new TestCase(['oo']);
+    const t = new TestCase(['oo']);
     t.sendKeys('$~');
     t.expect(['oO']);
     t.expectCursor(1,1);
@@ -31,7 +31,7 @@ describe.only('swapping case', function() {
   });
 
   it('should swap case in visual mode', async function() {
-    let t = new TestCase(['swapCaseHere']);
+    const t = new TestCase(['swapCaseHere']);
     t.sendKeys('0llvlll~');
     t.expect(['swAPcAseHere']);
     t.expectCursor(1, 2);
@@ -44,7 +44,7 @@ describe.only('swapping case', function() {
   });
 
   it('should undo case swapping', async function() {
-    let t = new TestCase(['swapCaseHere']);
+    const t = new TestCase(['swapCaseHere']);
     t.sendKeys('0~');
     t.expect(['SwapCaseHere']);
     t.sendKeys('u');
@@ -54,6 +54,15 @@ describe.only('swapping case', function() {
     t.expect(['swAPcaseHere']);
     t.sendKeys('u');
     t.expect(['swapCaseHere']);
+
+    await t.done();
+  });
+
+  it('should swap case for multiple selected lines', async function() {
+    const t = new TestCase(['swap', 'case', 'here']);
+    t.sendKeys('0Vj~');
+    t.expect(['SWAP', 'CASE', 'here']);
+    t.expectCursor(2, 0);
 
     await t.done();
   });

--- a/test/tests/swap_case.ts
+++ b/test/tests/swap_case.ts
@@ -1,6 +1,5 @@
 /* globals describe, it */
 import TestCase from '../testcase';
-// import { RegisterTypes } from '../../src/assets/js/register';
 
 describe.only('swapping case', function() {
   it('should swap case at cursor and moving cursor to the right', async function() {
@@ -9,6 +8,12 @@ describe.only('swapping case', function() {
     t.sendKey('~');
     t.expect(['Oo']);
     t.expectCursor(1, 1);
+
+    t.sendKeys('0');
+    t.sendKey('~');
+    t.expect(['oo']);
+    t.expectCursor(1, 1);
+
     await t.done();
   });
 
@@ -17,6 +22,24 @@ describe.only('swapping case', function() {
     t.sendKeys('$~');
     t.expect(['oO']);
     t.expectCursor(1,1);
+
+    t.sendKeys('~');
+    t.expect(['oo']);
+    t.expectCursor(1,1);
+
     await t.done();
-  })
+  });
+
+  it('should swap case in visual mode', async function() {
+    let t = new TestCase(['swapCaseHere']);
+    t.sendKeys('0llvlll~');
+    t.expect(['swAPcAseHere']);
+    t.expectCursor(1, 2);
+
+    t.sendKeys('v0~');
+    t.expect(['SWaPcAseHere']);
+    t.expectCursor(1, 0);
+
+    await t.done();
+  });
 });

--- a/test/tests/swap_case.ts
+++ b/test/tests/swap_case.ts
@@ -66,4 +66,27 @@ describe('swapping case', function() {
 
     await t.done();
   });
+
+  it('should swap case for multiple selected nodes, without children', async function () {
+    const t = new TestCase([
+      {
+        text: 'swap',
+        children: ['case']
+      },
+      'here',
+      'not here'
+    ]);
+    t.sendKeys('0Vjj~');
+    t.expect([
+      {
+        text: 'SWAP',
+        children: ['case']
+      },
+      'HERE',
+      'not here'
+    ]);
+    t.expectCursor(3, 0);
+
+    await t.done();
+  })
 });

--- a/test/tests/swap_case.ts
+++ b/test/tests/swap_case.ts
@@ -88,5 +88,18 @@ describe('swapping case', function() {
     t.expectCursor(3, 0);
 
     await t.done();
+  });
+
+  it('should undo multiline case swapping', async function() {
+    const t = new TestCase(['swap', 'case']);
+    t.sendKeys('0V~');
+    t.expect(['SWAP', 'case']);
+    t.expectCursor(1, 0);
+
+    t.sendKeys('u');
+    t.expect(['swap', 'case']);
+    t.expectCursor(1, 0);
+
+    await t.done();
   })
 });

--- a/test/tests/swap_case.ts
+++ b/test/tests/swap_case.ts
@@ -21,11 +21,11 @@ describe('swapping case', function() {
     const t = new TestCase(['oo']);
     t.sendKeys('$~');
     t.expect(['oO']);
-    t.expectCursor(1,1);
+    t.expectCursor(1, 1);
 
     t.sendKeys('~');
     t.expect(['oo']);
-    t.expectCursor(1,1);
+    t.expectCursor(1, 1);
 
     await t.done();
   });
@@ -101,5 +101,5 @@ describe('swapping case', function() {
     t.expectCursor(1, 0);
 
     await t.done();
-  })
+  });
 });

--- a/test/tests/swap_case.ts
+++ b/test/tests/swap_case.ts
@@ -42,4 +42,19 @@ describe.only('swapping case', function() {
 
     await t.done();
   });
+
+  it('should undo case swapping', async function() {
+    let t = new TestCase(['swapCaseHere']);
+    t.sendKeys('0~');
+    t.expect(['SwapCaseHere']);
+    t.sendKeys('u');
+    t.expect(['swapCaseHere']);
+
+    t.sendKeys('llvll~');
+    t.expect(['swAPcaseHere']);
+    t.sendKeys('u');
+    t.expect(['swapCaseHere']);
+
+    await t.done();
+  });
 });


### PR DESCRIPTION
functionality for swapping case for character / visual / visual_line, closes #135 

for visual_line implemented case swapping the same way text-formatting is implemented - without modifying children

I'm well aware this is not the must-have feature, but I wanted to start small :)