### PR TITLE
try to make IME input available

### DIFF
--- a/src/assets/ts/keyEmitter.ts
+++ b/src/assets/ts/keyEmitter.ts
@@ -109,7 +109,9 @@ export default class KeyEmitter extends EventEmitter {
   public listen() {
     // IME event
     $(document).on('compositionend', (e: any) => {
-      this.emit('keydown', e.originalEvent.data);
+      e.originalEvent.data.split('').forEach((key) => {
+        this.emit('keydown', key);
+      });
     });
 
     return $(document).keydown(e => {

--- a/src/assets/ts/keyEmitter.ts
+++ b/src/assets/ts/keyEmitter.ts
@@ -107,7 +107,16 @@ export default class KeyEmitter extends EventEmitter {
   }
 
   public listen() {
+    // IME event
+    $(document).on('compositionend', (e: any) => {
+      this.emit('keydown', e.originalEvent.data);
+    });
+
     return $(document).keydown(e => {
+      // IME input keycode is 229
+      if (e.keyCode === 229) {
+        return false;
+      }
       if (e.keyCode in ignoreMap) {
         return true;
       }

--- a/src/assets/ts/modes.ts
+++ b/src/assets/ts/modes.ts
@@ -162,10 +162,6 @@ registerMode({
         // simply insert the key
         await context.session.addCharsAtCursor([key]);
         return [null, context];
-      } else if (!/\w+/.test(key)) {
-        // key is IME input value
-        await context.session.addCharsAtCursor(key.split(''));
-        return [null, context];
       }
       return [key, context];
     },

--- a/src/assets/ts/modes.ts
+++ b/src/assets/ts/modes.ts
@@ -162,6 +162,10 @@ registerMode({
         // simply insert the key
         await context.session.addCharsAtCursor([key]);
         return [null, context];
+      } else if (!/\w+/.test(key)) {
+        // key is IME input value
+        await context.session.addCharsAtCursor(key.split(''));
+        return [null, context];
       }
       return [key, context];
     },


### PR DESCRIPTION
Use `compositionend` event to capture input method event to input CJK characters.

Works for me on Google Chrome and it may need optimization on other browsers.