### PR TITLE
Bugfix/home end keys

### DIFF
--- a/src/assets/ts/keyEmitter.ts
+++ b/src/assets/ts/keyEmitter.ts
@@ -57,6 +57,8 @@ const keyCodeMap: {[keyCode: number]: Key} = {
 
   33: 'page up',
   34: 'page down',
+  35: 'end',
+  36: 'home',
   37: 'left',
   38: 'up',
   39: 'right',

--- a/test/tests/basics.ts
+++ b/test/tests/basics.ts
@@ -126,6 +126,19 @@ describe('random set of basic tests', function() {
     await t.done();
   });
 
+  it("tests the cursor can move to start and end of line", async function() {
+    let t = new TestCase(['012345']);
+    t.expectCursor(1, 0);
+    t.sendKeys('$')
+    t.expectCursor(1, 5);
+    t.sendKeys('^')
+    t.expectCursor(1, 0);
+    t.sendKeys('end')
+    t.expectCursor(0, 5);
+    t.sendKeys('home')
+    t.expectCursor(1, 0);
+  })
+
   it("tests the cursor doesn't go before line", async function() {
     let t = new TestCase(['blahblah']);
     t.sendKeys('0d$iab');


### PR DESCRIPTION
The `home` and `end` keys are referred to in the default configuration, but the keyEmitter does not define the keycode mappings. This pull request adds the mappings.

I added a related test case, but it doesn't really test the change because the tests do not use the keycode mappings. The test I added passes both with and without the fix, so not very useful. I manually tested the `home` and `end` keys before and after the fix and it seems to work.

Another note: when I run `npm start`, I get this error:

```
src/server/dev.ts (71,93): Property 'port' does not exist on type 'string | AddressInfo'.
```
I commented out this line in order to get `npm start` to work. Do you see this error on your side?

```typescript
logger.info('Internal server listening on http://localhost:%d', http_server.address().port);
```