### PR TITLE
[plugin] Adding recursive expand plugin.

### DIFF
--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -5,6 +5,7 @@ import './marks';
 import './text_formatting';
 import './time_tracking';
 import './todo';
+import './recursive_expand';
 
 // for developers: uncomment the following lines
 /*

--- a/src/plugins/recursive_expand/index.tsx
+++ b/src/plugins/recursive_expand/index.tsx
@@ -1,0 +1,50 @@
+import * as _ from 'lodash';
+
+import { registerPlugin } from '../../assets/ts/plugins';
+import Session from '../../assets/ts/session';
+import logger from '../../shared/utils/logger';
+import Path from '../../assets/ts/path';
+
+export const pluginName = 'Recursive-Expand';
+
+registerPlugin(
+    {
+        name: pluginName,
+        author: 'Nikhil Sonti',
+        description: `Lets you recurisively expand or collapse a node`,
+    },
+    function (api) {
+
+        async function toggleRecursiveCollapse(session: Session, path: Path, collapse: boolean) {
+            logger.debug('Toggle state: ' + collapse + ' row = ' + path.row);
+            await session.document.setCollapsed(path.row, collapse);
+
+            if (await session.document.hasChildren(path.row)) {
+                let children = await session.document.getChildren(path);
+                logger.debug('No of children: ' + children.length);
+
+                children.forEach(async (child_path) => {
+                    await toggleRecursiveCollapse(session, child_path, collapse);
+                });
+            }
+        }
+
+        api.registerAction(
+            'toggle-expand',
+            'Toggle expand/collapse recursively',
+            async function ({ session }) {
+                let is_collapsed = await session.document.collapsed(session.cursor.row);
+                await toggleRecursiveCollapse(session, session.cursor.path, !is_collapsed);
+                await session.document.forceLoadTree(session.cursor.row, false);
+            },
+        );
+
+        api.registerDefaultMappings(
+            'NORMAL',
+            {
+                'toggle-expand': [['ctrl+e']],
+            },
+        );
+    },
+    (api => api.deregisterAll()),
+);

--- a/src/plugins/recursive_expand/index.tsx
+++ b/src/plugins/recursive_expand/index.tsx
@@ -42,7 +42,7 @@ registerPlugin(
         api.registerDefaultMappings(
             'NORMAL',
             {
-                'toggle-expand': [['ctrl+e']],
+                'toggle-expand': [['Z']],
             },
         );
     },


### PR DESCRIPTION
- Recursive expand on a given node, "tries" to recursively collapse/expand
all it's children.

- Note: Sometimes, I see that a node doesn't expand but on-clicking it expands further. I believe some logic with rendering update which is causing that.