### PR TITLE
Add basic clipboard support to yank-line

### DIFF
--- a/src/assets/ts/app.tsx
+++ b/src/assets/ts/app.tsx
@@ -394,11 +394,11 @@ $(document).ready(async () => {
   });
 
   session.on('yank', (content) => {
-    if(clientStore.getClientSetting('copyToClipboard')) {
-      if (typeof content === "string") {
+    if (clientStore.getClientSetting('copyToClipboard')) {
+      if (typeof content === 'string') {
         copyToClipboard(content);
-        session.showMessage("Copied to clipboard: "
-          + (content.length > 10 ? content.substr(0, 10) + "..." : content));
+        session.showMessage('Copied to clipboard: '
+          + (content.length > 10 ? content.substr(0, 10) + '...' : content));
       }
     }
   });
@@ -481,18 +481,17 @@ function copyToClipboard(text: string) {
   // https://stackoverflow.com/a/33928558/5937230
   if (window.clipboardData && window.clipboardData.setData) {
     // IE specific code path to prevent textarea being shown while dialog is visible.
-    return window.clipboardData.setData("Text", text);
-
-  } else if (document.queryCommandSupported && document.queryCommandSupported("copy")) {
-    var textarea = document.createElement("textarea");
+    return window.clipboardData.setData('Text', text);
+  } else if (document.queryCommandSupported && document.queryCommandSupported('copy')) {
+    const textarea = document.createElement('textarea');
     textarea.textContent = text;
-    textarea.style.position = "fixed";  // Prevent scrolling to bottom of page in MS Edge.
+    textarea.style.position = 'fixed';  // Prevent scrolling to bottom of page in MS Edge.
     document.body.appendChild(textarea);
     textarea.select();
     try {
-      return document.execCommand("copy");  // Security exception may be thrown by some browsers.
+      return document.execCommand('copy');  // Security exception may be thrown by some browsers.
     } catch (ex) {
-      console.warn("Copy to clipboard failed.", ex);
+      console.warn('Copy to clipboard failed.', ex);
       return false;
     } finally {
       document.body.removeChild(textarea);

--- a/src/assets/ts/components/settings.tsx
+++ b/src/assets/ts/components/settings.tsx
@@ -28,10 +28,12 @@ import HotkeysTableComponent from './hotkeysTable';
 import PluginsTableComponent from './pluginTable';
 import BackendSettingsComponent from './settings/backendSettings';
 import FileInput from './fileInput';
+import BehaviorSettingsComponent from './settings/behaviorSettings';
 
 enum TABS {
   DATA,
   THEME,
+  BEHAVIOR,
   HOTKEYS,
   PLUGIN,
   ABOUT,
@@ -450,6 +452,21 @@ export default class SettingsComponent extends React.Component<Props, State> {
                 }
               </div>
             </div>
+          </div>
+        ),
+      },
+      {
+        tab: TABS.BEHAVIOR,
+        heading: 'Behavior',
+        div: (
+          <div>
+            {
+              <div className='settings-content'>
+                <BehaviorSettingsComponent
+                  clientStore={session.clientStore}
+                />
+              </div>
+            }
           </div>
         ),
       },

--- a/src/assets/ts/components/settings/behaviorSettings.tsx
+++ b/src/assets/ts/components/settings/behaviorSettings.tsx
@@ -5,9 +5,12 @@ import { ClientStore } from '../../datastore';
 type Props = {
   clientStore: ClientStore;
 };
+
 type State = {
   copyToClipboard: boolean;
+  formattedCopy: boolean;
 };
+
 export default class BehaviorSettingsComponent extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
@@ -15,28 +18,41 @@ export default class BehaviorSettingsComponent extends React.Component<Props, St
     const clientStore = props.clientStore;
     this.state = {
       copyToClipboard: clientStore.getClientSetting('copyToClipboard'),
+      formattedCopy: clientStore.getClientSetting('formattedCopy'),
     };
     this.setCopyToClipboard = this.setCopyToClipboard.bind(this);
+    this.setFormattedCopy = this.setFormattedCopy.bind(this);
   }
 
   private setCopyToClipboard(copyToClipboard: boolean): boolean {
     this.setState({ copyToClipboard: copyToClipboard });
     this.props.clientStore.setClientSetting('copyToClipboard', copyToClipboard);
-    console.log("set copytoclipboard: " + this.props.clientStore.getClientSetting('copyToClipboard'));
     return this.state.copyToClipboard;
+  }
+
+  private setFormattedCopy(formattedCopy: boolean): boolean {
+    this.setState({ formattedCopy: formattedCopy });
+    this.props.clientStore.setClientSetting('formattedCopy', formattedCopy);
+    return this.state.formattedCopy;
   }
 
   public render() {
     return (
-      <div style={{ fontSize: "1.3em" }}>
+      <div style={{ fontSize: '1.3em' }}>
         <div style={{ marginBottom: 10 }}>
           These settings modify various aspects of the default Vimflowy behavior.
         </div>
-        <SettingsCheckbox id={"copyToClipboard"}
+        <SettingsCheckbox id={'copyToClipboard'}
           fn={this.setCopyToClipboard}
           checked={this.state.copyToClipboard}
-          name="Copy to system clipboard"
-          desc="copy yanked text to system clipboard"
+          name='Copy to system clipboard'
+          desc='copy yanked text to system clipboard'
+        />
+        <SettingsCheckbox id={'formattedCopy'}
+          fn={this.setFormattedCopy}
+          checked={this.state.formattedCopy}
+          name='Formatted block copy'
+          desc='format with indents and hyphens when copying bullets with children to system clipboard'
         />
       </div>
     );
@@ -51,20 +67,20 @@ interface SettingsCheckboxProps {
   checked: boolean;
 }
 
-class SettingsCheckbox extends React.Component<SettingsCheckboxProps, {}>{
+class SettingsCheckbox extends React.Component<SettingsCheckboxProps, {}> {
   constructor(props: SettingsCheckboxProps) {
     super(props);
   }
 
   public render() {
     return (
-      <div style={{ fontSize: "0.9em" }}>
-        <input type="checkbox" id={this.props.id} checked={this.props.checked} onChange={(e) => {
+      <div style={{ fontSize: '0.9em', marginBottom: '0.3em' }}>
+        <input type='checkbox' id={this.props.id} checked={this.props.checked} onChange={(e) => {
           this.props.fn(e.target.checked);
         }} />
-        <label htmlFor={this.props.id} style={{ marginLeft: "0.5rem" }}>
-          {this.props.name + " - "}
-          <span style={{ fontSize: "0.9em" }}>{this.props.desc}</span>
+        <label htmlFor={this.props.id} style={{ marginLeft: '0.5rem' }}>
+          {this.props.name + ' - '}
+          <span style={{ fontSize: '0.9em' }}>{this.props.desc}</span>
         </label>
       </div>
     );

--- a/src/assets/ts/components/settings/behaviorSettings.tsx
+++ b/src/assets/ts/components/settings/behaviorSettings.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react';
+
+import { ClientStore } from '../../datastore';
+
+type Props = {
+  clientStore: ClientStore;
+};
+type State = {
+  copyToClipboard: boolean;
+};
+export default class BehaviorSettingsComponent extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+
+    const clientStore = props.clientStore;
+    this.state = {
+      copyToClipboard: clientStore.getClientSetting('copyToClipboard'),
+    };
+    this.setCopyToClipboard = this.setCopyToClipboard.bind(this);
+  }
+
+  private setCopyToClipboard(copyToClipboard: boolean): boolean {
+    this.setState({ copyToClipboard: copyToClipboard });
+    this.props.clientStore.setClientSetting('copyToClipboard', copyToClipboard);
+    console.log("set copytoclipboard: " + this.props.clientStore.getClientSetting('copyToClipboard'));
+    return this.state.copyToClipboard;
+  }
+
+  public render() {
+    return (
+      <div style={{ fontSize: "1.3em" }}>
+        <div style={{ marginBottom: 10 }}>
+          These settings modify various aspects of the default Vimflowy behavior.
+        </div>
+        <SettingsCheckbox id={"copyToClipboard"}
+          fn={this.setCopyToClipboard}
+          checked={this.state.copyToClipboard}
+          name="Copy to system clipboard"
+          desc="copy yanked text to system clipboard"
+        />
+      </div>
+    );
+  }
+}
+
+interface SettingsCheckboxProps {
+  id: string;
+  name: string;
+  desc: string;
+  fn: (val: boolean) => void;
+  checked: boolean;
+}
+
+class SettingsCheckbox extends React.Component<SettingsCheckboxProps, {}>{
+  constructor(props: SettingsCheckboxProps) {
+    super(props);
+  }
+
+  public render() {
+    return (
+      <div style={{ fontSize: "0.9em" }}>
+        <input type="checkbox" id={this.props.id} checked={this.props.checked} onChange={(e) => {
+          this.props.fn(e.target.checked);
+        }} />
+        <label htmlFor={this.props.id} style={{ marginLeft: "0.5rem" }}>
+          {this.props.name + " - "}
+          <span style={{ fontSize: "0.9em" }}>{this.props.desc}</span>
+        </label>
+      </div>
+    );
+  }
+}

--- a/src/assets/ts/datastore.ts
+++ b/src/assets/ts/datastore.ts
@@ -24,6 +24,7 @@ Currently, DataStore has a synchronous API.  This may need to change eventually.
 export type ClientSettings = Theme & {
   showKeyBindings: boolean;
   hotkeys: any; // TODO
+  copyToClipboard: boolean;
 };
 
 type ClientSetting = keyof ClientSettings;
@@ -32,6 +33,7 @@ const default_client_settings: ClientSettings =
   Object.assign({}, defaultTheme, {
     showKeyBindings: true,
     hotkeys: {},
+    copyToClipboard: true,
   });
 
 export type LocalDocSettings = {

--- a/src/assets/ts/datastore.ts
+++ b/src/assets/ts/datastore.ts
@@ -25,6 +25,7 @@ export type ClientSettings = Theme & {
   showKeyBindings: boolean;
   hotkeys: any; // TODO
   copyToClipboard: boolean;
+  formattedCopy: boolean;
 };
 
 type ClientSetting = keyof ClientSettings;
@@ -34,6 +35,7 @@ const default_client_settings: ClientSettings =
     showKeyBindings: true,
     hotkeys: {},
     copyToClipboard: true,
+    formattedCopy: false,
   });
 
 export type LocalDocSettings = {

--- a/src/assets/ts/document.ts
+++ b/src/assets/ts/document.ts
@@ -248,7 +248,7 @@ export default class Document extends EventEmitter {
     return info;
   }
 
-  private async getInfo(row: Row): Promise<CachedRowInfo> {
+  public async getInfo(row: Row): Promise<CachedRowInfo> {
     errors.assert(row != null, 'Cannot get info for undefined');
     const cached = this.cache.get(row);
     if (cached !== null) {

--- a/src/assets/ts/session.ts
+++ b/src/assets/ts/session.ts
@@ -819,7 +819,6 @@ export default class Session extends EventEmitter {
   public async yankChars(path: Path, col: Col, nchars: number) {
     const line = await this.document.getLine(path.row);
     if (line.length > 0) {
-      console.log("yanking: " + line.join('').slice(col, col + nchars))
       this.emit('yank', line.join('').slice(col, col + nchars));
       this.register.saveChars(line.slice(col, col + nchars));
     }
@@ -1064,7 +1063,7 @@ export default class Session extends EventEmitter {
     const serialized = await Promise.all(siblings.map(
       async (x) => await this.document.serialize(x.row)
     ));
-    if(this.clientStore.getClientSetting('copyToClipboard')) {
+    if (this.clientStore.getClientSetting('copyToClipboard')) {
       const clip: string[] = [];
       // depth, collapsed, path
       const ls: [number, boolean, Path][] = [];
@@ -1072,7 +1071,7 @@ export default class Session extends EventEmitter {
       const recurse: (p: [number, Path]) => void = async (p: [number, Path]) => {
         const collapsed = (await this.document.getInfo(p[1].row)).collapsed;
         ls.push([p[0], collapsed, p[1]]);
-        if(collapsed) {
+        if (collapsed) {
           return;
         }
         const children = await this.document.getChildren(p[1]);
@@ -1080,9 +1079,12 @@ export default class Session extends EventEmitter {
           hasDepth = true;
           await recurse([p[0] + 1, children[k]]);
         }
-      }
+      };
       for (let k = 0; k < siblings.length; k++) {
         await recurse([0, siblings[k]]);
+      }
+      if (!this.clientStore.getClientSetting('formattedCopy')) {
+        hasDepth = false;
       }
       for (let k = 0; k < ls.length; k++) {
         const p: [number, boolean, Path] = ls[k];

--- a/src/assets/ts/session.ts
+++ b/src/assets/ts/session.ts
@@ -841,6 +841,7 @@ export default class Session extends EventEmitter {
 
   public async yankRowAtCursor() {
     const serialized_row = await this.document.serializeRow(this.cursor.row);
+    copyToClipboard(serialized_row.text);
     return this.register.saveSerializedRows([serialized_row]);
   }
 
@@ -1345,4 +1346,26 @@ export class InMemorySession extends Session {
       new ClientStore(new SynchronousInMemory()), doc, options
     );
   }
+}
+
+function copyToClipboard(text: string) {
+    // https://stackoverflow.com/a/33928558/5937230
+    if (document.queryCommandSupported && document.queryCommandSupported('copy')) {
+        let textarea = document.createElement('textarea');
+        textarea.textContent = text;
+        // Prevent scrolling to bottom of page in MS Edge.
+        textarea.style.position = 'fixed';
+        document.body.appendChild(textarea);
+        textarea.select();
+        try {
+            // Security exception may be thrown by some browsers.
+            return document.execCommand('copy');
+        } catch (ex) {
+            console.warn('Copy to clipboard failed.', ex);
+            return false;
+        } finally {
+            document.body.removeChild(textarea);
+        }
+    }
+    return false;
 }


### PR DESCRIPTION
Not sure if this is robust enough to add to master, but it's a proof-of-concept of copying to system clipboard (previously discussed in #250).

It uses `document.execCommand('copy')` which works well in modern browsers and can be triggered correctly from a keypress. This implementation only does anything with `yy`, copying the line's text to clipboard.