### PR TITLE
add ctrl+backspace in insert mode

### DIFF
--- a/src/assets/ts/configurations/vim.ts
+++ b/src/assets/ts/configurations/vim.ts
@@ -158,7 +158,7 @@ export const INSERT_MODE_MAPPINGS: HotkeyMapping = Object.assign({
   'delete-char-before': [['backspace'], ['shift+backspace']],
   'delete-to-line-beginning': [['ctrl+u']],
   'delete-to-line-end': [['ctrl+k']],
-  'delete-to-word-beginning': [['ctrl+w']],
+  'delete-to-word-beginning': [['ctrl+w'], ['ctrl+backspace']],
   // NOTE: paste-after doesn't make much sense for insert mode
   'paste-before': [['ctrl+y']],
   'split-line': [['enter']],
@@ -206,7 +206,7 @@ export const WORKFLOWY_MODE_MAPPINGS: HotkeyMapping = Object.assign({
   'delete-char-before': [['backspace'], ['shift+backspace']],
   'delete-to-line-beginning': [['ctrl+u']],
   'delete-to-line-end': [['ctrl+k']],
-  'delete-to-word-beginning': [['ctrl+w']],
+  'delete-to-word-beginning': [['ctrl+w'], ['ctrl+backspace']],
   // NOTE: paste-after doesn't make much sense for insert mode
   'paste-before': [['ctrl+y']],
   'split-line': [['enter']],


### PR DESCRIPTION
Small change to add Ctrl+Backspace as a default keybinding for `delete-to-word-beginning` in insert mode. I only did a bit of light testing but it seems to work just fine and the keypresses are consumed correctly.

(As discussed in #302)
