### PR TITLE
Got keyEmitter.ts working with spanish keyboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ npm-debug.log
 
 /todo
 .DS_Store
+.idea

--- a/src/server/webpack_configs.ts
+++ b/src/server/webpack_configs.ts
@@ -17,7 +17,7 @@ export function getDevConfig(config: BuildConfig = {}): webpack.Configuration {
   const srcdir = config.srcdir || defaultSrcDir;
   const outdir = config.outdir || defaultBuildDir;
   return {
-    devtool: 'eval',
+    devtool: 'eval-source-map',
     entry: [
       'webpack-dev-server/client?http://localhost:3000',
       'webpack/hot/only-dev-server',


### PR DESCRIPTION
Hi,

I needed to use vimflowy with a spanish keyboard so I made a quick re-implementation of eventEmmiter.ts. I can't currently type characters like áéí that depend on dead keys but everything else seems to be working on chrome.

I don't really have time to code a solid multi-language implementation however, but I think this implementation could be more generic than the original one. I think it could work for many different localizations because it doesn't depend on a hardcoded keymap, instead, it uses the keydownevent.key property that contains the localized character the user typed regardless of the keyboard or language they are using.

It would be nice if someone could test this approach with an US keyboard or other keyboards.

Right now this is just a fast attempt at a possible generic solution, it isn't ready to be merged or complete.
